### PR TITLE
Add support for nikic/fast-route < 2.0, fix dockblock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4.0",
         "laravel/lumen-framework": "~5.0",
-        "nikic/fast-route": "0.4 - <2.0"
+        "nikic/fast-route": ">=0.4 <2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4.0",
         "laravel/lumen-framework": "~5.0",
-        "nikic/fast-route": "0.4 - 1.0"
+        "nikic/fast-route": "0.4 - 1.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4.0",
         "laravel/lumen-framework": "~5.0",
-        "nikic/fast-route": "0.4 - 1.*"
+        "nikic/fast-route": "0.4 - <2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",

--- a/src/RouteBindingServiceProvider.php
+++ b/src/RouteBindingServiceProvider.php
@@ -8,7 +8,7 @@ class RouteBindingServiceProvider extends ServiceProvider
     /**
      * The binder instance
      *
-     * @var mmghv\LumenRouteBinding\BindingResolver
+     * @var BindingResolver
      */
     protected $binder;
 


### PR DESCRIPTION
nikic/fast-route 1.1 is the latest stable but the version constraint in this package forced 1.0.