### PR TITLE
Duplicated binding vars using classname as index

### DIFF
--- a/src/BindingResolver.php
+++ b/src/BindingResolver.php
@@ -68,6 +68,7 @@ class BindingResolver
         if (!empty($this->implicitBindings) || !empty($this->bindings)) {
             foreach ($vars as $var => $value) {
                 $vars[$var] = $this->resolveBinding($var, $value);
+                $vars[get_class($vars[$var])] = $vars[$var];
             }
         }
 

--- a/src/BindingResolver.php
+++ b/src/BindingResolver.php
@@ -67,8 +67,11 @@ class BindingResolver
         // If no composite binding found, check for explicit and implicit bindings
         if (!empty($this->implicitBindings) || !empty($this->bindings)) {
             foreach ($vars as $var => $value) {
-                $vars[$var] = $this->resolveBinding($var, $value);
-                $vars[get_class($vars[$var])] = $vars[$var];
+                $resolved = $this->resolveBinding($var, $value);
+                $vars[$var] = $resolved;
+                if (is_object($resolved)) {
+                    $vars[get_class($resolved)] = $resolved;
+                }
             }
         }
 


### PR DESCRIPTION
duplicated variables when resolving explicit & implicit bindings using their classnames as index, in order to support route bindings with just type hinting their classes without using strict variable names.
e.g. 

> function(\App\Book **$item**)

 wouldn't be resolved before and dependency injection which passes an empty model would take over the argument but now it should be resolved.